### PR TITLE
Fix Dialogue Skipper after OOB scene transition

### DIFF
--- a/Events/Dialogue2DEventArgs.cs
+++ b/Events/Dialogue2DEventArgs.cs
@@ -1,5 +1,4 @@
 using UnityEngine;
-using UnityEngine.SceneManagement;
 using UniverseLib.Utility;
 #if ML
 using Il2Cpp;
@@ -38,7 +37,7 @@ public sealed class Dialogue2DEventArgs : DialogueEventArgs
 
         return new(
             objectName,
-            SceneManager.GetActiveScene().name,
+            novella.gameObject.scene.name,
             novella.indexStringDialogue,
             novella.textNeed ?? string.Empty,
             speaker: null,

--- a/Events/Dialogue3DEventArgs.cs
+++ b/Events/Dialogue3DEventArgs.cs
@@ -1,5 +1,4 @@
 using UnityEngine;
-using UnityEngine.SceneManagement;
 #if ML
 using Il2Cpp;
 #elif BIE
@@ -33,7 +32,8 @@ public sealed class Dialogue3DEventArgs : DialogueEventArgs
         new(
             instance,
             instance.name,
-            SceneManager.GetActiveScene().name,
+            // Object scene — GetActiveScene() is wrong with additive chapter loads.
+            instance.gameObject.scene.name,
             instance.indexString,
             instance.textPrint,
             instance.speaker,

--- a/Events/DialogueTTTEventArgs.cs
+++ b/Events/DialogueTTTEventArgs.cs
@@ -1,5 +1,4 @@
 using UnityEngine;
-using UnityEngine.SceneManagement;
 using UniverseLib.Utility;
 #if ML
 using Il2Cpp;
@@ -40,7 +39,7 @@ public sealed class DialogueTTTEventArgs : DialogueEventArgs
 
         return new(
             objectName,
-            SceneManager.GetActiveScene().name,
+            ticTacToe.gameObject.scene.name,
             novella?.indexStringDialogue ?? 0,
             novella?.textNeed ?? string.Empty,
             speaker: null,

--- a/Events/DialogueTicTacToeEventArgs.cs
+++ b/Events/DialogueTicTacToeEventArgs.cs
@@ -8,11 +8,11 @@ using BepInEx.IL2CPP;
 
 namespace KappiMod.Events;
 
-public sealed class DialogueTTTEventArgs : DialogueEventArgs
+public sealed class DialogueTicTacToeEventArgs : DialogueEventArgs
 {
     private readonly Location18_TicTacToe TicTacToe;
 
-    private DialogueTTTEventArgs(
+    private DialogueTicTacToeEventArgs(
         string objectName,
         string sceneName,
         int indexString,
@@ -26,7 +26,7 @@ public sealed class DialogueTTTEventArgs : DialogueEventArgs
         TicTacToe = ticTacToe;
     }
 
-    public static DialogueTTTEventArgs Create(
+    public static DialogueTicTacToeEventArgs Create(
         Location18_TicTacToe ticTacToe,
         DialoguePatchType patchType
     )

--- a/Patches/DialogueStartPatch.cs
+++ b/Patches/DialogueStartPatch.cs
@@ -91,7 +91,7 @@ public sealed class DialogueStartPatch : IPatch
 
         try
         {
-            var args = DialogueTTTEventArgs.Create(ticTacToe, DialoguePatchType.Postfix);
+            var args = DialogueTicTacToeEventArgs.Create(ticTacToe, DialoguePatchType.Postfix);
             _instance?.OnPostfixDialogueStart?.Invoke(_instance, args);
         }
         catch (Exception ex)


### PR DESCRIPTION
Closes #24 

Softlock ignore lookups now use the dialogue’s own scene, so they still match after OOB / unusual scene transitions